### PR TITLE
Fix docker image starting and immediately failing

### DIFF
--- a/environments/docker/environment.go
+++ b/environments/docker/environment.go
@@ -593,8 +593,7 @@ func (n *dockerClusterNode) start(cli *docker.Client, caDir, netName string, net
 		dockerAPI: cli,
 		ContainerConfig: &container.Config{
 			Image: "hashicorp/vault:latest",
-			Entrypoint: []string{"/bin/sh", "-c", "update-ca-certificates && " +
-				"exec /usr/local/bin/docker-entrypoint.sh hashicorp/vault server -log-level=trace -dev-plugin-dir=./vault/config -config /vault/config/local.json"},
+			Entrypoint: []string{"/bin/sh", "-c", "/usr/local/bin/docker-entrypoint.sh vault server -log-level=trace -dev-plugin-dir=./vault/config -config /vault/config/local.json"},
 			Env: []string{
 				"VAULT_CLUSTER_INTERFACE=eth0",
 				"VAULT_API_ADDR=https://127.0.0.1:8200",


### PR DESCRIPTION
The docker in `vault-testing-stepwise` is immediately failing upon start because of 2 problems:

- When updating `vault` image to `hashicorp/vault` due to the image registry change (`vault:latest` doesnt exist anymore) in https://github.com/hashicorp/vault-testing-stepwise/pull/9 , the `vault server` command in the entrypoint got replaced by `hashicorp/vault server`, which doesn't exist inside the container.

- Old containers had the `update-ca-certificates` command, they now don't have it anymore:

Testing update-ca-certificate on the newest image: binary is not present
```
➜  docker run -it hashicorp/vault sh
/ # update-ca-certificates
sh: update-ca-certificates: not found
```

And in an old image:

```
➜ docker run -it vault:1.13.3 sh
/ # update-ca-certificates
/ # echo $?
0
```


I'm not sure if this should still be used for vault plugins acceptance tests, it seems to be used in `hashicorp/vault` for AWS plugin tests here: https://github.com/hashicorp/vault/blob/main/builtin/logical/aws/stepwise_test.go#L19 but the current state of this repo is not working so I'm not sure how tests are passing... 


Resolves https://github.com/hashicorp/vault-testing-stepwise/issues/10